### PR TITLE
WIP: Use container memory limits instead of fixed heap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN set -x \
     && chown -R daemon:daemon  "${JIRA_INSTALL}/temp" \
     && chown -R daemon:daemon  "${JIRA_INSTALL}/work" \
     && sed --in-place          "s/java version/openjdk version/g" "${JIRA_INSTALL}/bin/check-java.sh" \
+    && sed --in-place          's/-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY}/-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap/' "${JIRA_INSTALL}/bin/setenv.sh" \
     && echo -e                 "\njira.home=$JIRA_HOME" >> "${JIRA_INSTALL}/atlassian-jira/WEB-INF/classes/jira-application.properties" \
     && touch -d "@0"           "${JIRA_INSTALL}/conf/server.xml"
 


### PR DESCRIPTION
Tried this on Kubernetes but it caused the following error.

> Setup: Your memory allocation pool settings need attention
> 
> JIRA runs in a Java virtual machine (JVM), and this JVM is allocated an amount of memory to enable JIRA to run. These amounts can be manually configured.

The maximum memory allocation pool (-Xmx) is required to be at least 786m.

Opened as https://jira.atlassian.com/browse/JRASERVER-67303.